### PR TITLE
Disassociate Emacs Lisp

### DIFF
--- a/grammars/lisp.cson
+++ b/grammars/lisp.cson
@@ -13,7 +13,6 @@ fileTypes: [
   'cl'
   'l'
   'mud'
-  'el'
 ]
 
 foldingStartMarker: '\\(\\s*$'


### PR DESCRIPTION
I, err, don't know if you'll agree with this or not, but I thought I'd try anyway. =)

I know a dedicated language package for Emacs Lisp didn't exist when this package was published, but I [changed that last night](https://github.com/Alhadis/language-emacs-lisp#emacs-lisp-support).

More to the point, one can't have this package and my one installed at the same time; all `.el` files become marked as Common Lisp. My theory is that Atom goes through loaded packages alphabetically, and links a file extension to the first one that lists it. Since "Common Lisp" would get sorted before "Emacs Lisp", that's what causes the confusion...
